### PR TITLE
MDTimepicker now requires a `callback` argument when initialized. The `callback` is a function that will be called when the "ok" button is clicked, and it will automatically be passed the time selected. Functions identically to the MDDatePicker now.

### DIFF
--- a/kivymd/uix/picker.py
+++ b/kivymd/uix/picker.py
@@ -508,9 +508,11 @@ class MDTimePicker(
     ThemableBehavior, FloatLayout, ModalView, RectangularElevationBehavior
 ):
     time = ObjectProperty()
+    callback = ObjectProperty()
 
-    def __init__(self, **kwargs):
+    def __init__(self, callback, **kwargs):
         super().__init__(**kwargs)
+        self.callback = callback
         self.current_time = self.ids.time_picker.time
 
     def set_time(self, time):
@@ -528,6 +530,7 @@ class MDTimePicker(
     def close_ok(self):
         self.current_time = self.ids.time_picker.time
         self.time = self.current_time
+        self.callback(self.time)
         self.dismiss()
 
 


### PR DESCRIPTION
MDTimepicker now requires a `callback` argument when initialized. The `callback` is a function that will be called when the "ok" button is clicked, and it will automatically be passed the time selected. Functions identically to the MDDatePicker now.